### PR TITLE
Fixed a typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ or
 
 ```clojure
 (ns your-project.core
-  (:require [tiger.core :as stripe]))
+  (:require [tiger.core :as stripe]
             [tiger.events :as events]
             [tiger.plans :as plans]
             [tiger.customers :as customers]
-            [tiger.subscriptions :as subscriptions]
+            [tiger.subscriptions :as subscriptions]))
  
 (stripe/set-api-key! "your api key")
 


### PR DESCRIPTION
Was trying to copy and paste the namespace requirements and saw a weird issue. Figured Id fix it here too :^)